### PR TITLE
Support user provided arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ const argvForJournalCtl = (process.argv.length > 2) ?
   ['-b', '-f', '-o', 'json'];
 
 const journalctl = spawn('journalctl', argvForJournalCtl);
+const settingsRegEx = new RegExp('\{(.*?)\}', 'g')
 
 journalctl.stdout
   .pipe(split2())
@@ -55,7 +56,7 @@ journalctl.stdout
 
     let message = '';
 
-    let matches = settings.output.match(new RegExp('\{(.*?)\}', 'g'));
+    let matches = settings.output.match(settingsRegEx);
 
     for (match of matches) {
       match = match.replace(/\{|\}/g, '');

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "homepage": "https://github.com/96aa48/journally#readme",
   "dependencies": {
-    "chalk": "^1.1.3"
+    "chalk": "^1.1.3",
+    "split2": "^2.1.0"
   }
 }


### PR DESCRIPTION
Great package! Are you considering PRs?

This PR fixes #1 by doing the following:


* Support user provided arguments. If the user provides arguments, pass those to journalctl instead of using the default arguments.
* Cleans up the line splitting. The original code would break if a chunk of the stream came through that container only part of an entry. I saw this occur when running some of the journalctl commands that output lots of data.
* Only creates the regex for extracting data from settings once per execution. Probably not a huge impact, but saves some cycles.

So, you can do:

```
journally --since today
```

or any other journalctl command.